### PR TITLE
Add min SOL notification feature

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,3 +21,6 @@ NODE_ENV=development
 
 # Database connection string
 DATABASE_URL=
+
+# Minimum SOL amount to notify for transfers
+MIN_SOL_NOTIFICATION=1

--- a/README.md
+++ b/README.md
@@ -101,13 +101,15 @@ Follow these simple steps to setup Handi Cat locally on your machine
 
 8. (Optional) setup a custom RPC provider inside of `RPC_ENDPOINTS` environment variable, you can place as many endpoints as you want if you folow them up with a comma. `e.g: https://rpc1.com,https://rpc2.com`
 
-9. Start the bot
+9. (Optional) set `MIN_SOL_NOTIFICATION` to configure the minimum SOL amount required before a transfer notification is sent
+
+10. Start the bot
 
 ```sh
   pnpm start
 ```
 
-10. That's it! now your local version of Handi Cat is ready to use.
+11. That's it! now your local version of Handi Cat is ready to use.
 
 <p align="center"><img src="./showcase/cli-pic.png" width="95%" alt="Screenshot of bot succesfully running"/></>
 


### PR DESCRIPTION
## Summary
- add MIN_SOL_NOTIFICATION env var
- document how to set the minimum SOL amount for transfer messages
- only send telegram alerts when transaction SOL amount meets threshold

## Testing
- `pnpm format:check`
- `pnpm run start:test` *(fails: Cannot find module '@prisma/client' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_684738bf55308333995766ec23ed5491